### PR TITLE
Remove redundant assignment in reduce() initialization.

### DIFF
--- a/v1/difference_sequence.py
+++ b/v1/difference_sequence.py
@@ -102,7 +102,6 @@ class DifferenceSequence:
 
         index = Index()
         index_out = Index()
-        keys_todo = defaultdict(set)
         output = []
 
         for collection in self._inner:


### PR DESCRIPTION
The variable gets immediately overwritten in the loop. The assignment operation has no effect.